### PR TITLE
feat: add swap counter

### DIFF
--- a/src/notes/SWAPp.masm
+++ b/src/notes/SWAPp.masm
@@ -32,23 +32,23 @@ const.SWAP_COUNT=0x0003
 const.SWAP_CREATOR_ID=0x0004
 
 # SWAPp Script Hash
-const.SWAPP_SCRIPT_HASH=0x0005
-const.P2ID_SCRIPT_HASH=0x0006
+const.SWAPP_SCRIPT_HASH=0x0006
+const.P2ID_SCRIPT_HASH=0x0007
 
 # temp variables
-const.OFFERED_ASSET=0x0007
-const.TOKEN_A_ID=0x0008
-const.TOKEN_B_ID=0x0009
-const.TOKEN_A_AMT=0x000A
-const.TOKEN_B_AMT=0x000B
-const.TOKEN_B_AMT_IN=0x000C
-const.TOKEN_A_AMT_OUT=0x000D
-const.IS_PARTIAL_FILL=0x000E
+const.OFFERED_ASSET=0x0008
+const.TOKEN_A_ID=0x0009
+const.TOKEN_B_ID=0x000A
+const.TOKEN_A_AMT=0x000B
+const.TOKEN_B_AMT=0x000C
+const.TOKEN_B_AMT_IN=0x000D
+const.TOKEN_A_AMT_OUT=0x000E
+const.IS_PARTIAL_FILL=0x000F
 
 # MISC
-const.SWAP_SERIAL_NUM=0x000F
-const.P2ID_SERIAL_NUM=0x0010
-const.P2ID_OUTPUT_RECIPIENT=0x0011
+const.SWAP_SERIAL_NUM=0x0010
+const.P2ID_SERIAL_NUM=0x0011
+const.P2ID_OUTPUT_RECIPIENT=0x0012
 
 # ERRORS
 # =================================================================================================
@@ -191,6 +191,7 @@ proc.get_note_inputs_commitment
     # => [Digest]
 end
 
+# @dev debug this
 # inputs: [creator_id, SWAP_COUNT, TAG, ASSET_REQUESTED_REMAINING, PAYBACK_RECIPIENT]
 # ouputs: [SWAP_RECIPIENT]
 proc.get_swap_note_inputs_commitment
@@ -201,13 +202,11 @@ proc.get_swap_note_inputs_commitment
     mem_storew.81 dropw
     mem_storew.80 dropw
 
-    push.17.80
+    debug.mem.80.84
 
-    push.302 debug.mem.80.84 drop
+    push.24.80
 
     exec.note::compute_inputs_hash
-
-    push.555 debug.stack drop
 
 end
 
@@ -362,16 +361,18 @@ proc.execute_SWAPp
     mem_store.TOKEN_B_AMT_IN
     # => []
 
-    # store OFFERED_ASSET into memory
-    push.OFFERED_ASSET exec.note::get_assets assert.err=ERR_SWAP_WRONG_NUMBER_OF_ASSETS
+    # store asset into memory at address 3
+    exec.note::get_assets assert.err=ERR_SWAP_WRONG_NUMBER_OF_ASSETS
     # => [ptr]
 
-    # load the asset
+    debug.mem
+
+    # load the asset and add it to the account
     mem_loadw
     # => [OFFERED_ASSET]
 
     # store token_a_id and offered asset
-    dup mem_store.TOKEN_A_ID
+    dup mem_store.TOKEN_A_ID mem_storew.OFFERED_ASSET
     # => []
 
     # store token_a_AMT to mem addr 8
@@ -381,6 +382,8 @@ proc.execute_SWAPp
     # store note inputs into memory starting at address 0
     push.0 exec.note::get_inputs
     # => [num_inputs, inputs_ptr]
+
+    debug.mem
 
     # make sure the number of inputs is N
     eq.17 assert.err=ERR_SWAP_WRONG_NUMBER_OF_INPUTS
@@ -481,11 +484,9 @@ proc.execute_SWAPp
     exec.build_p2id_recipient_hash
     # => [P2ID_RECIPIENT]
 
-    mem_storew.PAYBACK_RECIPIENT
-
     # TODO: add aux value
     # 1) send token B amt to creator
-    push.OFFCHAIN_NOTE push.0 mem_load.PAYBACK_TAG mem_load.TOKEN_B_AMT_IN push.0.0 mem_load.TOKEN_B_ID
+    mem_loadw.PAYBACK_RECIPIENT push.OFFCHAIN_NOTE push.0 mem_load.PAYBACK_TAG mem_load.TOKEN_B_AMT_IN push.0.0 mem_load.TOKEN_B_ID
     # => [requested_token_id, 0, 0, token_b_AMT_IN, tag, note_type, aux, P2ID_RECIPIENT]
 
     # @dev P2ID creation
@@ -504,8 +505,21 @@ proc.execute_SWAPp
     # => [is_partial_fill]
 
     if.true
+
+        mem_load.SWAP_CREATOR_ID
+
+        padw mem_loadw.P2ID_SCRIPT_HASH
+
+        mem_load.SWAP_COUNT
+
+        padw mem_loadw.SWAP_SERIAL_NUM
+
+        exec.get_p2id_serial_num
+
+        exec.build_p2id_recipient_hash
+
         # 3) create SWAPp' and calculate token_a' & token_b'
-        padw mem_loadw.PAYBACK_RECIPIENT
+        # padw mem_loadw.PAYBACK_RECIPIENT
         # => [PAYBACK_RECIPIENT]
 
         mem_load.TOKEN_B_AMT mem_load.TOKEN_B_AMT_IN sub
@@ -523,10 +537,9 @@ proc.execute_SWAPp
         mem_load.SWAP_CREATOR_ID
         # => [creator_id, SWAP_COUNT, TAG, ASSET_REQUESTED_REMAINING, PAYBACK_RECIPIENT]
 
-        push.111 debug.stack debug.mem drop
+        push.111 debug.stack drop
 
         exec.get_swap_note_inputs_commitment
-        # => [INPUTS_COMMITMENT, ...]
 
         push.222 debug.stack drop
 
@@ -610,3 +623,4 @@ begin
     end
 
 end
+

--- a/tests/mock_integration/partial_order_fill_test.rs
+++ b/tests/mock_integration/partial_order_fill_test.rs
@@ -172,7 +172,7 @@ pub fn create_partial_swap_note(
     println!("inputs.commitment: {:?}", inputs.commitment());
 
     // println!("p2id note script {:?}", payback_recipient.script().hash());
-/*     println!("p2id serial num {:?}", p2id_serial_num);
+    /*     println!("p2id serial num {:?}", p2id_serial_num);
     println!("p2id serial num 1 {:?}", p2id_serial_num_1);
     println!("p2id payback recipient {:?}", payback_recipient_word);
     println!(


### PR DESCRIPTION
Modified the SWAPp note to have a "swap counter" that prevents the possibility of a SWAPp note from outputting two identical P2ID notes, which would result in a locking of user funds. 

More refactoring is required, however, this is a working PoC of the swap counter. 

Will edit tests to use the new `create_swap_note` format that use the new SWAPp inputs in subsequent PRs. 